### PR TITLE
fix: tenant creation

### DIFF
--- a/src/components/CreateTenant.tsx
+++ b/src/components/CreateTenant.tsx
@@ -72,7 +72,7 @@ export default function CreateTenant({
           const t = await get(createdTenant.id)
           if (t.provisioningStatus === 'completed') {
             window.clearInterval(id)
-            setTenant(createdTenant)
+            setTenant(t)
           } else if (t.provisioningStatus === 'fatal') {
             // failed to create the tenant
             window.clearInterval(id)

--- a/src/layouts/FrameworkLayout.tsx
+++ b/src/layouts/FrameworkLayout.tsx
@@ -104,7 +104,7 @@ export default function Layout(props: IProps) {
 
   useEffect(() => {
     setField('tenant', tenant)
-    setField('tenant_domain', tenant?.domains[0])
+    setField('tenant_domain', (tenant?.domains || [])[0])
   }, [tenant])
 
   return (


### PR DESCRIPTION
- set correct tenant after creation is completed
- frameworks page, tenant might be undefined, so we need to take an empty array as fallback