### PR TITLE
fix: download sample button

### DIFF
--- a/src/components/DownloadSample.tsx
+++ b/src/components/DownloadSample.tsx
@@ -78,7 +78,8 @@ export default function DownloadSampleButton({
   }
 
   // downloading a file only works from anchor elements, so that's what I did
-  function downloadExample() {
+  function downloadExample(e: React.MouseEvent<HTMLElement>) {
+    e.preventDefault()
     const a = document.createElement('a')
     a.style.display = 'none'
     a.href = url


### PR DESCRIPTION
if the button is inside a form, it must prevent default form submission

closes #67 